### PR TITLE
Ajustes de tratamentos de erros e parse de vars double

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -137,6 +137,10 @@ namespace SuperCompilador
                 messageTextBox.Text = $"Erro na linha {line} - {invalidSymbol} {err.Message}";
                 return;
             }
+            catch (Exception err) // Erro generico - vide #33 - parar
+            {
+                return;
+            }
 
             if (noError)
                 messageTextBox.Text = "programa compilado com sucesso";

--- a/Form1.cs
+++ b/Form1.cs
@@ -141,31 +141,32 @@ namespace SuperCompilador
             if (noError)
                 messageTextBox.Text = "programa compilado com sucesso";
 
-            var enviromentPath = System.Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
-
-            Console.WriteLine(enviromentPath);
-            var paths = enviromentPath.Split(';');
-            var exePath = paths.Select(x => Path.Combine(x, "ilasm.exe"))
-                               .Where(x => File.Exists(x))
-                               .FirstOrDefault();
-
-            var p = new Process
-            {
-                StartInfo =
-                 {
-                     FileName = exePath,
-                     WorkingDirectory = $"{sintatico.fileIL.Substring(0, sintatico.fileIL.LastIndexOf("\\"))}",
-                     Arguments = $"/exe {sintatico.fileIL}"
-                 }
-            }.Start();
-
-            string exe = sintatico.fileIL;
-            exe = exe.Substring(0, exe.IndexOf(".")) + ".exe";
-
-            var p2 = new Process
-            {
-                StartInfo = { FileName = exe, }
-            }.Start();
+            // Código para compilar o .il em .exe e chamar a execução
+            //var enviromentPath = System.Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
+            //
+            //Console.WriteLine(enviromentPath);
+            //var paths = enviromentPath.Split(';');
+            //var exePath = paths.Select(x => Path.Combine(x, "ilasm.exe"))
+            //                   .Where(x => File.Exists(x))
+            //                   .FirstOrDefault();
+            //
+            //var p = new Process
+            //{
+            //    StartInfo =
+            //     {
+            //         FileName = exePath,
+            //         WorkingDirectory = $"{sintatico.fileIL.Substring(0, sintatico.fileIL.LastIndexOf("\\"))}",
+            //         Arguments = $"/exe {sintatico.fileIL}"
+            //     }
+            //}.Start();
+            //
+            //string exe = sintatico.fileIL;
+            //exe = exe.Substring(0, exe.IndexOf(".")) + ".exe";
+            //
+            //var p2 = new Process
+            //{
+            //    StartInfo = { FileName = exe, }
+            //}.Start();
         }
 
         private void helpStripMenuItem_Click(object sender, EventArgs e)

--- a/Semantico.cs
+++ b/Semantico.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace SuperCompilador
 {
@@ -28,12 +29,10 @@ namespace SuperCompilador
                         string type1 = typeStack.Pop();
                         string type2 = typeStack.Pop();
 
-                        if (type1 == "float64" || type2 == "float64")
-                            typeStack.Push("float64");
-                        else if (type1 == "int64" || type2 == "int64")
-                            typeStack.Push("int64");
+                        if (type1 == type2 && (type1 == "int64" || type1 == "float64"))
+                            typeStack.Push(type1);
                         else
-                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipos incompatíveis em expressão aritmética", token.getPosition());
 
                         code += "add\n";
                     }
@@ -44,10 +43,10 @@ namespace SuperCompilador
                         string type1 = typeStack.Pop();
                         string type2 = typeStack.Pop();
 
-                        if (type1 == "float64" || type2 == "float64")
-                            typeStack.Push("float64");
+                        if (type1 == type2 && (type1 == "int64" || type1 == "float64"))
+                            typeStack.Push(type1);
                         else
-                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipos incompatívis em expressão aritmética", token.getPosition());
 
                         code += "sub\n";
                     }
@@ -58,12 +57,10 @@ namespace SuperCompilador
                         string type1 = typeStack.Pop(); 
                         string type2 = typeStack.Pop();
 
-                        if (type1 == "float64" || type2 == "float64")
-                            typeStack.Push("float64");
-                        else if (type1 == "int64" || type2 == "int64")
-                            typeStack.Push("int64");
+                        if (type1 == type2 && (type1 == "int64" || type1 == "float64"))
+                            typeStack.Push(type1);
                         else
-                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipos incompatíveis em expressão aritmética", token.getPosition());
 
                         code += "mul\n";
                     }
@@ -77,7 +74,7 @@ namespace SuperCompilador
                         if (type1 == type2)
                             typeStack.Push(type1);
                         else
-                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipos incompatíveis em expressão aritmética", token.getPosition());
 
                         code += "div\n";
                     }
@@ -113,9 +110,14 @@ namespace SuperCompilador
                     {
                         typeStack.Push("float64");
 
-                        double value = Convert.ToDouble(token.getLexeme());
+                        string lexema = token.getLexeme();
 
-                        code += $"ldc.r8 {value}\n";
+                        double value = Convert.ToDouble(lexema, CultureInfo.InvariantCulture);
+
+                        String valorFormatado = value.ToString();
+                        valorFormatado = valorFormatado.Replace(',', '.');
+
+                        code += $"ldc.r8 {valorFormatado}\n";
                     }
                 break;
 
@@ -126,7 +128,7 @@ namespace SuperCompilador
                         if (type == "float64" || type == "int64")
                             typeStack.Push(type);
                         else
-                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipo incompatível em expressão aritmética", token.getPosition());
                     }
                 break;
 
@@ -137,7 +139,7 @@ namespace SuperCompilador
                         if (type == "float64" || type == "int64")
                             typeStack.Push(type);
                         else
-                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipo incompatível em expressão aritmética", token.getPosition());
 
                         code += "ldc.i8 - 1\n";
                         code += "conv.r8\n";
@@ -189,7 +191,7 @@ namespace SuperCompilador
                         if (type == "bool")
                             typeStack.Push("bool");
                         else
-                            throw new SemanticError("tipo(s) incompatível(is) em expressão lógica", token.getPosition());
+                            throw new SemanticError("tipo incompatível em expressão lógica", token.getPosition());
 
                         code += "ldc.i4.1\n";
                         code += "xor\n";
@@ -211,7 +213,7 @@ namespace SuperCompilador
                     {
                         code += ".assembly extern mscorlib {}\n"         +
                                 ".assembly _object_code{}\n"             +
-                                ".module _object_code.exe\n"             +
+                                ".module _object_code.exe\n\n"           +
                                 ".class public _UNIC{ \n"                +
                                 ".method static public void _main() {\n" +
                                 ".entrypoint\n";
@@ -236,7 +238,7 @@ namespace SuperCompilador
                         if (type1 == "bool" && type2 == "bool")
                             typeStack.Push("bool");
                         else
-                            throw new SemanticError("tipo(s) incompatível(is) em expressão lógica", token.getPosition());
+                            throw new SemanticError("tipos incompatíveis em expressão lógica", token.getPosition());
 
                         code += "and";
                     }
@@ -250,7 +252,7 @@ namespace SuperCompilador
                         if (type1 == "bool" && type2 == "bool")
                             typeStack.Push("bool");
                         else
-                            throw new SemanticError("tipo(s) incompatível(is) em expressão lógica", token.getPosition());
+                            throw new SemanticError("tipos incompatíveis em expressão lógica", token.getPosition());
 
                         code += "or";
                     }

--- a/Semantico.cs
+++ b/Semantico.cs
@@ -29,10 +29,15 @@ namespace SuperCompilador
                         string type1 = typeStack.Pop();
                         string type2 = typeStack.Pop();
 
-                        if (type1 == type2 && (type1 == "int64" || type1 == "float64"))
-                            typeStack.Push(type1);
+                        if ((type1 == "float64" || type1 == "int64") && (type2 == "float64" || type2 == "int64"))
+                        {
+                            if (type1 == "float64" || type2 == "float64")
+                                typeStack.Push("float64");
+                            else
+                                typeStack.Push("int64");
+                        }
                         else
-                            throw new SemanticError("tipos incompatíveis em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
 
                         code += "add\n";
                     }
@@ -43,10 +48,15 @@ namespace SuperCompilador
                         string type1 = typeStack.Pop();
                         string type2 = typeStack.Pop();
 
-                        if (type1 == type2 && (type1 == "int64" || type1 == "float64"))
-                            typeStack.Push(type1);
+                        if ((type1 == "float64" || type1 == "int64") && (type2 == "float64" || type2 == "int64"))
+                        {
+                            if (type1 == "float64" || type2 == "float64")
+                                typeStack.Push("float64");
+                            else
+                                typeStack.Push("int64");
+                        }
                         else
-                            throw new SemanticError("tipos incompatívis em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
 
                         code += "sub\n";
                     }
@@ -57,10 +67,15 @@ namespace SuperCompilador
                         string type1 = typeStack.Pop(); 
                         string type2 = typeStack.Pop();
 
-                        if (type1 == type2 && (type1 == "int64" || type1 == "float64"))
-                            typeStack.Push(type1);
+                        if ((type1 == "float64" || type1 == "int64") && (type2 == "float64" || type2 == "int64"))
+                        {
+                            if (type1 == "float64" || type2 == "float64")
+                                typeStack.Push("float64");
+                            else
+                                typeStack.Push("int64");
+                        }
                         else
-                            throw new SemanticError("tipos incompatíveis em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
 
                         code += "mul\n";
                     }
@@ -71,10 +86,15 @@ namespace SuperCompilador
                         string type1 = typeStack.Pop();
                         string type2 = typeStack.Pop();
 
-                        if (type1 == type2)
-                            typeStack.Push(type1);
+                        if ((type1 == "float64" || type1 == "int64") && (type2 == "float64" || type2 == "int64"))
+                        {
+                            if (type1 == "float64" || type2 == "float64")
+                                typeStack.Push("float64");
+                            else
+                                typeStack.Push("int64");
+                        }
                         else
-                            throw new SemanticError("tipos incompatíveis em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
 
                         code += "div\n";
                     }
@@ -128,7 +148,7 @@ namespace SuperCompilador
                         if (type == "float64" || type == "int64")
                             typeStack.Push(type);
                         else
-                            throw new SemanticError("tipo incompatível em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
                     }
                 break;
 
@@ -139,7 +159,7 @@ namespace SuperCompilador
                         if (type == "float64" || type == "int64")
                             typeStack.Push(type);
                         else
-                            throw new SemanticError("tipo incompatível em expressão aritmética", token.getPosition());
+                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
 
                         code += "ldc.i8 - 1\n";
                         code += "conv.r8\n";
@@ -157,7 +177,7 @@ namespace SuperCompilador
                         if (type1 == type2)
                             typeStack.Push("bool");
                         else
-                            throw new SemanticError("tipos incompatíveis em expressão relacional", token.getPosition());
+                            throw new SemanticError("tipo(s) incompatível(is) em expressão relacional", token.getPosition());
 
                         switch (relationalOperator)
                         {
@@ -191,7 +211,7 @@ namespace SuperCompilador
                         if (type == "bool")
                             typeStack.Push("bool");
                         else
-                            throw new SemanticError("tipo incompatível em expressão lógica", token.getPosition());
+                            throw new SemanticError("tipo(s) incompatível(is) em expressão lógica", token.getPosition());
 
                         code += "ldc.i4.1\n";
                         code += "xor\n";
@@ -212,10 +232,10 @@ namespace SuperCompilador
                 case 15:
                     {
                         code += ".assembly extern mscorlib {}\n"         +
-                                ".assembly _object_code{}\n"             +
-                                ".module _object_code.exe\n\n"           +
-                                ".class public _UNIC{ \n"                +
-                                ".method static public void _main() {\n" +
+                                ".assembly _codigo_objeto{}\n" +
+                                ".module _codigo_objeto.exe\n\n" +
+                                ".class public _UNICA{ \n"                +
+                                ".method static public void _principal() {\n" +
                                 ".entrypoint\n";
                     }
                 break;
@@ -238,7 +258,7 @@ namespace SuperCompilador
                         if (type1 == "bool" && type2 == "bool")
                             typeStack.Push("bool");
                         else
-                            throw new SemanticError("tipos incompatíveis em expressão lógica", token.getPosition());
+                            throw new SemanticError("tipo(s) incompatível(is) em expressão lógica", token.getPosition());
 
                         code += "and";
                     }
@@ -252,7 +272,7 @@ namespace SuperCompilador
                         if (type1 == "bool" && type2 == "bool")
                             typeStack.Push("bool");
                         else
-                            throw new SemanticError("tipos incompatíveis em expressão lógica", token.getPosition());
+                            throw new SemanticError(" tipo(s) incompatível(is) em expressão lógica", token.getPosition());
 
                         code += "or";
                     }
@@ -263,10 +283,15 @@ namespace SuperCompilador
                         string type1 = typeStack.Pop();
                         string type2 = typeStack.Pop();
 
-                        if (type1 == type2 && (type1 == "int64" || type1 == "float64"))
-                            typeStack.Push(type1);
+                        if ((type1 == "float64" || type1 == "int64") && (type2 == "float64" || type2 == "int64"))
+                        {
+                            if (type1 == "float64" || type2 == "float64")
+                                typeStack.Push("float64");
+                            else
+                                typeStack.Push("int64");
+                        }
                         else
-                            throw new SemanticError("tipos incompatíveis em expressão relacional", token.getPosition());
+                            throw new SemanticError("tipo(s) incompatível(is) em expressão aritmética", token.getPosition());
 
                         code += "rem";
                     }
@@ -350,7 +375,7 @@ namespace SuperCompilador
                         {
                             symbolTable[id] = varType;
 
-                            code += $".locals({varType} {id})\n";
+                            code += $".locals ({varType} {id})\n";
                         }
 
                         ids.Clear();

--- a/Sintatico.cs
+++ b/Sintatico.cs
@@ -112,12 +112,19 @@ namespace SuperCompilador
 
             while (!step());
 
-            string filePath = semanticAnalyser.objFile;
-            filePath = filePath.Substring(0, filePath.IndexOf(".")) + ".il";
+            try
+            {
+                string filePath = semanticAnalyser.objFile;
+                filePath = filePath.Substring(0, filePath.IndexOf(".")) + ".il";
 
-            File.WriteAllText(filePath, semanticAnalyser.code);
+                File.WriteAllText(filePath, semanticAnalyser.code);
 
-            fileIL = filePath;
+                fileIL = filePath;
+            }
+            catch (Exception e) // Arquivo não foi salvo antes de compilar - apenas ignora 
+            {
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
- Ajustados tratamentos de erro para tipos em operações.
- Adicionado catch dummy para ignorar erro ao compilar sem ter salvo arquivo
- Criada formatação para garantir formato do parse de double independentemente do sistema operacional.